### PR TITLE
Cygwin

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -76,7 +76,7 @@
 ;; Notes on using this package with Cygwin:
 
 ;; You can override using Win32's find with cygwin's find by putting
-;; (setq ffip-find "/usr/bin/find")
+;; (setq ffip-find-command "/usr/bin/find")
 ;; in your init.el
 
 ;; In order to make sure that the paths returned by cygwin find 


### PR DESCRIPTION
Hey guys,

Huge fan of the functionality in find-file-in-project.  I just started doing some Rails development at home -- my box is a Win7/Emacs/Cygwin hybrid.  Unfortunately I had to spend some time hacking in order to get FFIP working as I expected.

There were two main issues: find in Emacs was getting Win32 find by default and Emacs couldn't find the resulting cygwin mount points.

I needed to move the "find" invocation out into its own variable to solve the first issue.  The second issue was fixed by adding another emacs module that made Emacs less stupid about cygwin paths in general.  I feel like the ~60minutes or so I spent tracking this down might be helpful to someone else, so I added general comments  about getting this working at the top of the header file.

Thank you for reading this!
