### PR TITLE
File Sorting

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -171,6 +171,18 @@ directory they are found in so that they are unique."
 	  (append (cdr top) sorted-file-alist (list (car top)))
 	(append top sorted-file-alist)))))
 
+(defun ffip-open-projects ()
+  "Prompt to switch to the last edited file of an open project"
+  (interactive)
+  (let (projects)
+    (dolist (buf (buffer-list))
+      (with-current-buffer buf
+	(when (and (buffer-file-name buf) (ffip-project-root))
+	  (if projects
+	      (pushnew (cons (ffip-project-root) buf) projects :test (lambda (x y) (string= (car x) (car y))))
+	    (setq projects (adjoin (cons (ffip-project-root) buf) projects))))))
+    (switch-to-buffer
+     (assoc (completing-read "Jump to open project: " projects) 'projects))))
 
 ;;;###autoload
 (defun find-file-in-project ()

--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -182,7 +182,7 @@ directory they are found in so that they are unique."
 	      (pushnew (cons (ffip-project-root) buf) projects :test (lambda (x y) (string= (car x) (car y))))
 	    (setq projects (adjoin (cons (ffip-project-root) buf) projects))))))
     (switch-to-buffer
-     (assoc (completing-read "Jump to open project: " projects) 'projects))))
+     (assoc (completing-read "Jump to open project: " projects) projects))))
 
 ;;;###autoload
 (defun find-file-in-project ()

--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -142,9 +142,16 @@ directory they are found in so that they are unique."
                                    ffip-find-options ffip-limit))))))
 
 
+(defun ffip-mtime (filename)
+  "According to this number we soert the files"
+  (float-time (nth 4 (file-attributes filename))))
+
 (defun ffip-sort-file-alist (file-alist)
   "Show them in buffer order"
-  (let ((top nil))
+  (let ((top nil)
+	(file-alist (sort file-alist (lambda (f1 f2)
+				       (> (ffip-mtime (cdr f1)) (ffip-mtime (cdr f2)))))))
+
     (loop for tuple in (reverse (delq nil  ;; The tuples we need to push up in reverse order
 				      (mapcar (lambda (buf)
 						(let ((fname (buffer-file-name buf)))

--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -148,10 +148,7 @@ directory they are found in so that they are unique."
 
 (defun ffip-sort-file-alist (file-alist)
   "Show them in buffer order"
-  (let ((top nil)
-	(file-alist (sort file-alist (lambda (f1 f2)
-				       (> (ffip-mtime (cdr f1)) (ffip-mtime (cdr f2)))))))
-
+  (let ((top nil))
     (loop for tuple in (reverse (delq nil  ;; The tuples we need to push up in reverse order
 				      (mapcar (lambda (buf)
 						(let ((fname (buffer-file-name buf)))
@@ -163,9 +160,11 @@ directory they are found in so that they are unique."
 	  (setq file-alist (delete tuple file-alist))
 	  (push tuple top))
 
-    (if (string= (cdar top) (buffer-file-name (current-buffer)))
-	(append (cdr top) file-alist (list (car top)))
-      (append top file-alist))))
+    (let ((file-alist (sort file-alist (lambda (f1 f2)
+					 (> (ffip-mtime (cdr f1)) (ffip-mtime (cdr f2)))))))
+      (if (string= (cdar top) (buffer-file-name (current-buffer)))
+	  (append (cdr top) file-alist (list (car top)))
+	(append top file-alist)))))
 
 
 ;;;###autoload

--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -191,7 +191,6 @@ directory they are found in so that they are unique."
 	   (chosen (if (and (boundp 'ido-mode) ido-mode)
 		       (ido-completing-read "Jump to open project: " barel-roots)
 		     (completing-read "jump to open project: " barel-roots))))
-      (message (format "Project roots found: %s" (princ barel-roots)))
       (switch-to-buffer
        (cdr (assoc chosen projects))))))
 

--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -85,7 +85,7 @@ Use this to exclude portions of your project: \"-not -regex \\\".*svn.*\\\"\".")
 
 This overrides variable `ffip-project-root' when set.")
 
-(defvar ffip-limit 512
+(defvar ffip-limit 50
   "Limit results to this many files.")
 
 (defvar ffip-full-paths nil


### PR DESCRIPTION
Files are being thrown in the random (from the user's standpoint) order that find spits them out. Files should be shown in the oerder switch-buffer has the corresponding buffers and the files that are not open should follow in mtime order.
For the future mtime order should be taken care of by the shell command itself so that ffip-limit actually shows the most recent files, not random ones.