### PR TITLE
Add option to prune directories from find command

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -72,6 +72,10 @@ May be set using .dir-locals.el. Checks each entry if set to a list.")
     "*.sh" "*.erl" "*.hs" "*.ml")
   "List of patterns to look for with `find-file-in-project'.")
 
+(defvar ffip-prune-patterns
+  '(".git")
+  "List of directory patterns to not decend into when listing files in `find-file-in-project'.")
+
 (defvar ffip-find-options ""
   "Extra options to pass to `find' when using `find-file-in-project'.
 
@@ -113,9 +117,15 @@ This overrides variable `ffip-project-root' when set.")
                   (car file-cons))))
 
 (defun ffip-join-patterns ()
-  "Turn `ffip-paterns' into a string that `find' can use."
+  "Turn `ffip-patterns' into a string that `find' can use."
   (mapconcat (lambda (pat) (format "-name \"%s\"" pat))
              ffip-patterns " -or "))
+
+(defun ffip-prune-patterns ()
+  "Turn `ffip-prune-patterns' into a string that `find' can use."
+  (mapconcat (lambda (pat) (format "-name \"%s\"" pat))
+             ffip-prune-patterns " -or "))
+
 
 (defun ffip-project-files ()
   "Return an alist of all filenames in the project and their path.
@@ -137,8 +147,8 @@ directory they are found in so that they are unique."
                   (add-to-list 'file-alist file-cons)
                   file-cons)))
             (split-string (shell-command-to-string
-                           (format "find %s -type f \\( %s \\) %s | head -n %s"
-                                   root (ffip-join-patterns)
+                           (format "find %s -type d -a \\( %s \\) -prune -o -type f \\( %s \\) -print %s | head -n %s"
+                                   root (ffip-prune-patterns) (ffip-join-patterns)
                                    ffip-find-options ffip-limit))))))
 
 ;;;###autoload


### PR DESCRIPTION
For some projects I set things like `'("vendor" "log" "images" "tmp")` and it cuts way down on the time for some searches and the total number of files.

Love the project btw. I use it every day.
