### PR TITLE
Improve handling of files and directories that contain spaces.

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -139,7 +139,7 @@ directory they are found in so that they are unique."
             (split-string (shell-command-to-string
                            (format "find %s -type f \\( %s \\) %s | head -n %s"
                                    root (ffip-join-patterns)
-                                   ffip-find-options ffip-limit))))))
+                                   ffip-find-options ffip-limit)) "[\r\n]+"))))
 
 ;;;###autoload
 (defun find-file-in-project ()


### PR DESCRIPTION
Limit the split-string regex to \r and \n; by default it includes
all whitespace characters as delimiters.

This is inteded to address [Issues with directories that contain spaces](https://github.com/technomancy/find-file-in-project/issues/5).

Thanks for the script by the way, couldn't live without it!
