### PR TITLE
Don't declare unsafe local variables as safe

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -173,10 +173,8 @@ setting the variable `ffip-project-root'."
 ;;;###autoload
 (progn
   (put 'ffip-patterns 'safe-local-variable 'listp)
-  (put 'ffip-find-options 'safe-local-variable 'stringp)
   (put 'ffip-project-file 'safe-local-variable 'stringp)
   (put 'ffip-project-root 'safe-local-variable 'stringp)
-  (put 'ffip-project-root-function 'safe-local-variable 'functionp)
   (put 'ffip-limit 'safe-local-variable 'integerp))
 
 (provide 'find-file-in-project)


### PR DESCRIPTION
I didn't know anything about safe-local-variables until I started customizing ffip, so maybe I'm wrong, but it seems to me that by declaring these variables safe you're creating vulnerabilities that allow execution of arbitrary shell commands in the case of ffip-find-options, and arbitrary elisp code in the case of ffip-project-root-function.
