### PR TITLE
Omit nulls in split-string

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -229,7 +229,7 @@ directory they are found in so that they are unique."
                         (add-to-list 'file-alist file-cons)
                         file-cons)))
                   ;; #15 improving handling of directories containing space
-                  (split-string (shell-command-to-string cmd) "[\r\n]+")))
+                  (split-string (shell-command-to-string cmd) "[\r\n]+" t)))
 
     ;; restore the original default-directory
     (cd old-default-directory)


### PR DESCRIPTION
find-file-in-project.el (ffip-project-files): Avoid the empty strings.

Fixes #26