### PR TITLE
Properly quote open-another-window in ffip-find-files

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -579,11 +579,11 @@ If KEYWORD is list, it's the list of file names."
           ;; only one item in project files
           (if (listp file) (setq file (cdr file)))
           (if ,find-directory
-              (if ,open-another-window
+              (if (quote ,open-another-window)
                   (dired-other-window file)
                 (switch-to-buffer (dired file)))
             ;; open file
-            (if ,open-another-window
+            (if (quote ,open-another-window)
                 (find-file-other-window file)
               (find-file file))
             ;; goto line if needed

--- a/tests/general.el
+++ b/tests/general.el
@@ -43,6 +43,16 @@
     (ffip-find-files nil nil)
     (should ivy-read-called)))
 
+(ert-deftest ffip-test-ffip-open-another ()
+  (let (files
+        (prefix-args '(4 (4))))
+    (dolist (open-another-arg prefix-args)
+      (setq ffip-project-root default-directory)
+      (setq files (mapcar 'car (ffip-project-search "ivy" nil)))
+      (should (= (length files) 1))
+      (should (not (active-minibuffer-window)))
+      (ffip-find-files "ivy" open-another-arg))))
+
 (ert-deftest ffip-ffip-show-diff ()
   (let (files
         (ffip-diff-backends '((with-temp-buffer


### PR DESCRIPTION
The prefix argument can be a list, in which case there was the error "4 is not a function" on emacs25 with C-u M-x find-file-in-project.