### PR TITLE
Rename fake ivy.el to ivy-mock.el

### DIFF
--- a/tests/ivy-mock.el
+++ b/tests/ivy-mock.el
@@ -10,5 +10,3 @@
                            action unwind re-builder matcher dynamic-collection caller)
   (setq ivy-read-called t)
   (message "`ivy-read' mockup is called"))
-
-(provide 'ivy)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd "$(dirname "$0")"
-emacs -batch -l cl-lib -l ert -l ivy.el -l ../find-file-in-project.el  -l general.el -l windows.el -f ert-run-tests-batch-and-exit
+emacs -batch -l cl-lib -l ert -l ivy-mock.el -l ../find-file-in-project.el  -l general.el -l windows.el -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
This prevents a potential issue when the test/ directory ended up
on the `load-path`.  In that case the fake ivy.el might get loaded
instead of the real one.

The `provide` form was dropped completely because the file is being
loaded using `load` instead of `require` anyway.