### PR TITLE
Set ffip-project-root during tests

### DIFF
--- a/tests/general.el
+++ b/tests/general.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'find-file-in-project)
+(setq ffip-project-root (file-name-directory "./"))
 
 (ert-deftest ffip-test-find-by-selected ()
   (let (files)


### PR DESCRIPTION
Self-tests in pbuilder, sbuild, et al fail without this

I discovered this while packaging ffip for Debian