### PR TITLE
Add an option for GNU find to follow symbolic path.

### DIFF
--- a/find-file-in-project.el
+++ b/find-file-in-project.el
@@ -326,6 +326,12 @@ May be set using .dir-locals.el.  Checks each entry if set to a list.")
 
 Use this to exclude portions of your project: \"-not -regex \\\".*svn.*\\\"\".")
 
+(defcustom ffip-find-pre-path-options ""
+  "Extra options to pass to `find' before path name options when using `find-file-in-project'.
+
+As required by `find', `-H', `-L', `-P', `-D' and `-O' must appear before the first path name, `.' for ffip's case.
+For example, use this to follow symbolic links inside your project: \"-L\".")
+
 (defvar ffip-project-root nil
   "If non-nil, overrides the project root directory location.")
 
@@ -610,7 +616,9 @@ BSD/GNU Find use glob pattern."
       (setq tgt
             (if is-finding-directory (format "-iwholename \"*%s\"" keyword)
               (ffip--create-filename-pattern-for-gnufind keyword)))
-      (setq fmt "%s . \\( %s \\) -prune -o -type %s %s %s %s -print")))
+      (setq fmt (concat "%s "
+                        ffip-find-pre-path-options
+                        " . \\( %s \\) -prune -o -type %s %s %s %s -print"))))
 
     (setq cmd (format fmt
                       (ffip--executable-find)


### PR DESCRIPTION
Hi,

Yesterday I tried to let ffip follow symbolic links with `ffip-find-options` set to `-L`, but `find` fails surprisingly:

    find . -type f -L
    find: unknown predicate `-L'

In man page of `find`, it says that the symbolic links must comes before path names in `Options` section:

> The  -H,  -L  and  -P options control the treatment of symbolic links.  Command-line arguments following these are taken to be names of
>       files or directories to be examined, up to the first argument that begins with `-', or the argument `(' or `!'.
>
> ...
>
> The five `real' options -H, -L, -P, -D and -O must appear before the first path name, if at all.

I tried to place value of `ffip-find-options` at the place of `.` and omit `.` when format'ing the final shell command(let `find` take the current directory by default),  but failed, as it is designed to fit in the `-o` branch of `find` expression.

So I add another option for this, and it can't affect rust fd hopefully.

Is there any better way to achieve this?
