### PR TITLE
Restore correct Debian installation instructions

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,7 +30,7 @@ It is also possible to use [[http://stable.melpa.org/#/find-file-in-project][mel
 Since =v3.7=, =Emacs 24.3= is required.
 
 Users of Debian ≥10 and derivatives can install find-file-in-project with the following command:
-=sudo apt-get install elpa-find-file-in-project=
+=sudo apt install elpa-find-file-in-project=
 * Setup
 ** Windows
 Windows setup is as easy as *installing [[http://cygwin.com][Cygwin]] or [[https://msys2.github.io/][MYSYS2]] at default directory of any driver*. =GNU Find= executable is detected automatically.


### PR DESCRIPTION
Apt has been recommended since 2016

https://itsfoss.com/apt-vs-apt-get-difference/