### PR TITLE
Revert "try to fix test for debian"

### DIFF
--- a/tests/ffip-tests.el
+++ b/tests/ffip-tests.el
@@ -140,9 +140,9 @@
       (goto-char 5)
       (should (file-exists-p (buffer-string)))
       ;; absolute path
-      (should (not (string= "tests/git-diff.diff" (replace-regexp-in-string "/<<PKGBUILDDIR>>/" "" (buffer-string)))))
+      (should (not (string= "tests/git-diff.diff" (buffer-string))))
       (ffip-fix-file-path-at-point)
       ;; relative path
-      (should (string= "tests/git-diff.diff" (replace-regexp-in-string "/<<PKGBUILDDIR>>/" "" (buffer-string)))))))
+      (should (string= "tests/git-diff.diff" (buffer-string))))))
 
 (ert-run-tests-batch-and-exit)


### PR DESCRIPTION
"PKGBUILDDIR" only exists conceptually and in logs, so this commit did not actually do anything.

This reverts commit a62eaa0b07d8d22f309ec07992283f0fc340ce17.